### PR TITLE
Allow a new name to be passed to upload()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": { "Upload": "src" }
     }

--- a/src/Upload/File.php
+++ b/src/Upload/File.php
@@ -292,16 +292,20 @@ class File extends \SplFileInfo
 
     /**
      * Upload file (delegated to storage object)
+     * @param  string $newName Give the file it a new name
      * @return bool
      * @throws \Upload\Exception\UploadException If file does not validate
      */
-    public function upload()
+    public function upload($newName = null)
     {
         if ($this->validate() === false) {
             throw new \Upload\Exception\UploadException('File validation failed');
         }
 
-        return $this->storage->upload($this);
+        // Update the name, leaving out the extension
+        $this->name = pathinfo($newName, PATHINFO_FILENAME);
+
+        return $this->storage->upload($this, $newName);
     }
 
     /********************************************************************************

--- a/src/Upload/Storage/Base.php
+++ b/src/Upload/Storage/Base.php
@@ -41,5 +41,5 @@ namespace Upload\Storage;
  */
 abstract class Base
 {
-    abstract public function upload(\Upload\File $file);
+    abstract public function upload(\Upload\File $file, $newName = null);
 }

--- a/src/Upload/Storage/FileSystem.php
+++ b/src/Upload/Storage/FileSystem.php
@@ -71,12 +71,20 @@ class FileSystem extends \Upload\Storage\Base
     /**
      * Upload
      * @param  \Upload\File $file The file object to upload
+     * @param  string $newName Give the file it a new name
      * @return bool
      * @throws \RuntimeException   If overwrite is false and file already exists
      */
-    public function upload(\Upload\File $file)
+    public function upload(\Upload\File $file, $newName = null)
     {
-        $newFile = $this->directory . $file->getNameWithExtension();
+        if (is_string($newName)) {
+            $fileName = strpos($newName, '.') ? $newName : $newName.'.'.$file->getExtension();
+
+        } else {
+            $fileName = $file->getNameWithExtension();
+        }
+
+        $newFile = $this->directory . $fileName;
         if ($this->overwrite === false && file_exists($newFile)) {
             $file->addError('File already exists');
             throw new \Upload\Exception\UploadException('File already exists');


### PR DESCRIPTION
Give an image a new name, which will respect the extension provided in the name, or if none is passed it will use the original extension.

I'd REALLY like to have set up a test for this with vfsStream but that would require a shitload of rewriting. Is this something you could look into going forwards? Otherwise I'd need to actually make a new file, which isn't cool and permission issues could cause tests to fail even though the code is fine.
