### PR TITLE
Lowercase file extensions

### DIFF
--- a/src/Upload/File.php
+++ b/src/Upload/File.php
@@ -187,7 +187,7 @@ class File extends \SplFileInfo
     public function getExtension()
     {
         if (!isset($this->extension)) {
-            $this->extension = pathinfo($this->originalName, PATHINFO_EXTENSION);
+            $this->extension = strtolower(pathinfo($this->originalName, PATHINFO_EXTENSION));
         }
 
         return $this->extension;


### PR DESCRIPTION
I know on Windows systems case is not an issue, but it's important to deal with lowercase file extensions. For example if someone creates a system that enables users to upload photos, but most cameras name photos in all uppercase. Hence getting lowercase file extensions.
