### PR TITLE
Restore functionality of getName

### DIFF
--- a/src/Upload/File.php
+++ b/src/Upload/File.php
@@ -209,7 +209,7 @@ class File extends \SplFileInfo
 
         return $this->mimetype;
     }
-    
+
     /**
      * Get md5
      * @return string
@@ -312,7 +312,9 @@ class File extends \SplFileInfo
         }
 
         // Update the name, leaving out the extension
-        $this->name = pathinfo($newName, PATHINFO_FILENAME);
+        if (is_string($newName)) {
+            $this->name = pathinfo($newName, PATHINFO_FILENAME);
+        }
 
         return $this->storage->upload($this, $newName);
     }


### PR DESCRIPTION
Check for a string when calling `upload()` & set the name if the `$newName` parameter is a string, otherwise leave it be.
Current behavior:

``` php
$file->setName("foo"); // Set the image name to "foo"
$file->upload(); // Upload the image
$file->getName(); // Returns an empty string
```

Fixed behavior:

``` php
$file->setName("foo"); // Set the image name to "foo"
$file->upload(); // Upload the image
$file->getName(); // Returns "foo" as expected
```
