### PR TITLE
Use `composer require` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,12 @@ Install composer in your project:
 curl -s https://getcomposer.org/installer | php
 ```
 
-Create a composer.json file in your project root:
-```json
-{
-    "require": {
-        "codeguy/upload": "*"
-    }
-}
+Require the package with composer:
+
 ```
-Install via composer:
+php composer.phar require codeguy/upload
 ```
-php composer.phar install
-```
+
 ## Author
 
 [Josh Lockhart](https://github.com/codeguy)


### PR DESCRIPTION
This replaces the manual editing of `composer.json` in the README with the more direct approach of using `composer require`.

But feel free to throw this PR in the trash if you prefer the `composer.json` way of doing things!