### PR TITLE
Creating a translation class which enables the usage of translated error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ When the HTML form is submitted, the server-side PHP code can validate and uploa
         $errors = $file->getErrors();
     }
 
+If you need to use translated messages, you can pass a translation object to the objects, like this:
+
+    <?php
+    $translation = new \Upload\Translation('pt-BR');
+    $storage = new \Upload\Storage\FileSystem('/path/to/directory', $translation);
+    $file = new \Upload\File('foo', $storage, $translation);
+
+    // Validate file upload
+    $file->addValidations(array(
+        // Ensure file is of type "image/png"
+        new \Upload\Validation\Mimetype('image/png', $translation),
+
+        // Ensure file has correct extension
+        new \Upload\Validation\Extension('png', $translation),
+
+        // Ensure file is no larger than 5M (use "B", "K", M", or "G")
+        new \Upload\Validation\Size('5M', 0, $translation)
+    ));
+
+    // Try to upload file
+    try {
+        // Success!
+        $file->upload();
+    } catch (\Exception $e) {
+        // Fail!
+        $errors = $file->getErrors();
+    }
+
 ## How to Install
 
 Install composer in your project:

--- a/src/Upload/Language/en.php
+++ b/src/Upload/Language/en.php
@@ -1,0 +1,22 @@
+<?php
+
+return array(
+  'The uploaded file exceeds the upload_max_filesize directive in php.ini'                     => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
+  'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'  => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
+  'The uploaded file was only partially uploaded'                                              => 'The uploaded file was only partially uploaded',
+  'No file was uploaded'                                                                       => 'No file was uploaded',
+  'Missing a temporary folder'                                                                 => 'Missing a temporary folder',
+  'Failed to write file to disk'                                                               => 'Failed to write file to disk',
+  'A PHP extension stopped the file upload'                                                    => 'A PHP extension stopped the file upload',
+  'Cannot find uploaded file identified by key: %s'                                            => 'Cannot find uploaded file identified by key: %s',
+  'The uploaded file was not sent with a POST request'                                         => 'The uploaded file was not sent with a POST request',
+  'File validation failed'                                                                     => 'File validation failed',
+  'Invalid file extension. Must be one of: %s'                                                 => 'Invalid file extension. Must be one of: %s',
+  'Invalid mimetype'                                                                           => 'Invalid mimetype',
+  'Invalid file size'                                                                          => 'Invalid file size',
+  'File size is too small'                                                                     => 'File size is too small',
+  'File size is too large'                                                                     => 'File size is too large',
+  'Directory does not exist'                                                                   => 'Directory does not exist',
+  'Directory is not writable'                                                                  => 'Directory is not writable',
+  'File already exists'                                                                        => 'File already exists'
+);

--- a/src/Upload/Language/pt-BR.php
+++ b/src/Upload/Language/pt-BR.php
@@ -1,0 +1,22 @@
+<?php
+
+return array(
+  'The uploaded file exceeds the upload_max_filesize directive in php.ini'                     => 'O tamanho do arquivo enviado excede o tamanho permitido pela diretiva upload_max_filesize do php.ini',
+  'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'  => 'O tamanho do arquivo enviado excede a diretiva MAX_FILE_SIZE especificada no formulário HTML',
+  'The uploaded file was only partially uploaded'                                              => 'Arquivo parcialmente enviado',
+  'No file was uploaded'                                                                       => 'Nenhum arquivo enviado',
+  'Missing a temporary folder'                                                                 => 'Nenhum diretório temporário encontrado',
+  'Failed to write file to disk'                                                               => 'Falha ao gravar o arquivo em disco',
+  'A PHP extension stopped the file upload'                                                    => 'Uma extensão PHP parou o envio do arquivo',
+  'Cannot find uploaded file identified by key: %s'                                            => 'Não foi possível encontrar o arquivo enviado com a chave: %s',
+  'The uploaded file was not sent with a POST request'                                         => 'O arquivo não foi enviado utilizando o método POST',
+  'File validation failed'                                                                     => 'Validação do arquivo falhou',
+  'Invalid file extension. Must be one of: %s'                                                 => 'Extensão de arquivo inválida. Deve ser uma das: %s',
+  'Invalid mimetype'                                                                           => 'Mimetype inválido',
+  'Invalid file size'                                                                          => 'Tamanho de arquivo inválido',
+  'File size is too small'                                                                     => 'Tamanho do arquivo muito pequeno',
+  'File size is too large'                                                                     => 'Tamanho do arquivo muito grande',
+  'Directory does not exist'                                                                   => 'Diretório não existe',
+  'Directory is not writable'                                                                  => 'Diretório sem permissão de escrita',
+  'File already exists'                                                                        => 'Arquivo já existe'
+);

--- a/src/Upload/Storage/Base.php
+++ b/src/Upload/Storage/Base.php
@@ -41,5 +41,26 @@ namespace Upload\Storage;
  */
 abstract class Base
 {
+    /**
+     * Translation object
+     * @var \Upload\Translation
+     */
+    protected $translation;
+
+    /**
+     * Get the translated message
+     * @param string $key    Message key
+     * @param array  $params List of positional placeholders values
+     * @return string
+     */
+    protected function getTranslation($key, array $params = array())
+    {
+        if ($this->translation === null) {
+            return vsprintf($key, $params);
+        }
+
+        return $this->translation->getMessage($key, $params);
+    }
+
     abstract public function upload(\Upload\File $file, $newName = null);
 }

--- a/src/Upload/Storage/FileSystem.php
+++ b/src/Upload/Storage/FileSystem.php
@@ -60,13 +60,15 @@ class FileSystem extends \Upload\Storage\Base
      * @throws \InvalidArgumentException                    If directory does not exist
      * @throws \InvalidArgumentException                    If directory is not writable
      */
-    public function __construct($directory, $overwrite = false)
+    public function __construct($directory, $overwrite = false, \Upload\Translation $translation = null)
     {
+        $this->translation = $translation;
+
         if (!is_dir($directory)) {
-            throw new \InvalidArgumentException('Directory does not exist');
+            throw new \InvalidArgumentException($this->getTranslation('Directory does not exist'));
         }
         if (!is_writable($directory)) {
-            throw new \InvalidArgumentException('Directory is not writable');
+            throw new \InvalidArgumentException($this->getTranslation('Directory is not writable'));
         }
         $this->directory = rtrim($directory, '/') . DIRECTORY_SEPARATOR;
         $this->overwrite = $overwrite;
@@ -90,8 +92,8 @@ class FileSystem extends \Upload\Storage\Base
 
         $newFile = $this->directory . $fileName;
         if ($this->overwrite === false && file_exists($newFile)) {
-            $file->addError('File already exists');
-            throw new \Upload\Exception\UploadException('File already exists');
+            $file->addError($this->getTranslation('File already exists'));
+            throw new \Upload\Exception\UploadException($this->getTranslation('File already exists'));
         }
 
         return $this->moveUploadedFile($file->getPathname(), $newFile);

--- a/src/Upload/Translation.php
+++ b/src/Upload/Translation.php
@@ -28,69 +28,63 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace Upload\Validation;
+namespace Upload;
 
 /**
- * Upload Validation Base
+ * Translation
  *
- * This class provides the common implementation and abstract interface
- * for all concrete Upload validation subclasses.
+ * This class provides the implementation for translated messages.
  *
- * @author  Josh Lockhart <info@joshlockhart.com>
- * @since   1.0.0
+ * @author  Ramiro Varandas Jr <ramirovjnr@gmail.com>
  * @package Upload
  */
-abstract class Base
+class Translation
 {
     /**
-     * The error message for this validation
-     * @var string
+     * Translation messages
+     * @var array
      */
-    protected $message;
+    protected $messages;
 
     /**
-     * Translation object
-     * @var \Upload\Translation
+     * Constructor
+     * @param  string                    $language Language prefix (i.e.: en, pt, pt-BR)
+     * @throws \InvalidArgumentException If translation file does not exist
      */
-    protected $translation;
-
-    /**
-     * Set error message
-     * @param string $message
-     */
-    public function setMessage($message)
+    public function __construct($language)
     {
-        $this->message = $message;
+        $this->loadTranslationFile($language);
     }
 
     /**
-     * Get error message
-     * @return string
+     * Load a translation file containing the messages used by the library
+     * @param string $language
+     * @throws \InvalidArgumentException If translation file does not exist
      */
-    public function getMessage()
+    protected function loadTranslationFile($language)
     {
-        return $this->message;
-    }
+        $filename = __DIR__ . "/Language/${language}.php";
 
-    /**
-     * Get the translated message
-     * @param string $key    Message key
-     * @param array  $params List of positional placeholders values
-     * @return string
-     */
-    protected function getTranslation($key, array $params = array())
-    {
-        if ($this->translation === null) {
-            return vsprintf($key, $params);
+        if (file_exists($filename) === false) {
+            throw new \InvalidArgumentException("Cannot find translation file for language: $language");
         }
 
-        return $this->translation->getMessage($key, $params);
+        $this->messages = require $filename;
     }
 
     /**
-     * Validate file
-     * @param  \Upload\File $file
-     * @return bool         True if file is valid, false if file is not valid
+     * Get a translation message
+     * @param string $key Message key
+     * @param array  $params Array containing positional placeholders values
+     * @return string
      */
-    abstract public function validate(\Upload\File $file);
+    public function getMessage($key, $params = array())
+    {
+        if (array_key_exists($key, $this->messages) === true) {
+            return vsprintf($this->messages[$key], $params);
+        } else {
+            return $key;
+        }
+    }
+
 }

--- a/src/Upload/Validation/Extension.php
+++ b/src/Upload/Validation/Extension.php
@@ -62,8 +62,10 @@ class Extension extends \Upload\Validation\Base
      * @example new \Upload\Validation\Extension(array('png','jpg','gif'))
      * @example new \Upload\Validation\Extension('png')
      */
-    public function __construct($allowedExtensions)
+    public function __construct($allowedExtensions, \Upload\Translation $translation = null)
     {
+        $this->translation = $translation;
+
         if (is_string($allowedExtensions)) {
             $allowedExtensions = array($allowedExtensions);
         }
@@ -86,7 +88,8 @@ class Extension extends \Upload\Validation\Base
         $isValid = true;
 
         if (!in_array($fileExtension, $this->allowedExtensions)) {
-            $this->setMessage(sprintf($this->message, implode(', ', $this->allowedExtensions)));
+            $extensions = array(implode(', ', $this->allowedExtensions));
+            $this->setMessage($this->getTranslation($this->message, $extensions));
             $isValid = false;
         }
 

--- a/src/Upload/Validation/Mimetype.php
+++ b/src/Upload/Validation/Mimetype.php
@@ -57,8 +57,11 @@ class Mimetype extends \Upload\Validation\Base
      * Constructor
      * @param array $mimetypes Array of valid mimetypes
      */
-    public function __construct($mimetypes)
+    public function __construct($mimetypes, \Upload\Translation $translation = null)
     {
+        $this->translation = $translation;
+        $this->message = $this->getTranslation($this->message);
+
         if (!is_array($mimetypes)) {
             $mimetypes = array($mimetypes);
         }

--- a/src/Upload/Validation/Size.php
+++ b/src/Upload/Validation/Size.php
@@ -66,8 +66,11 @@ class Size extends \Upload\Validation\Base
      * @param int $maxSize Maximum acceptable file size in bytes (inclusive)
      * @param int $minSize Minimum acceptable file size in bytes (inclusive)
      */
-    public function __construct($maxSize, $minSize = 0)
+    public function __construct($maxSize, $minSize = 0, \Upload\Translation $translation = null)
     {
+        $this->translation = $translation;
+        $this->message = $this->getTranslation($this->message);
+
         if (is_string($maxSize)) {
             $maxSize = \Upload\File::humanReadableToBytes($maxSize);
         }
@@ -90,12 +93,12 @@ class Size extends \Upload\Validation\Base
         $isValid = true;
 
         if ($fileSize < $this->minSize) {
-            $this->setMessage('File size is too small');
+            $this->setMessage($this->getTranslation('File size is too small'));
             $isValid = false;
         }
 
         if ($fileSize > $this->maxSize) {
-            $this->setMessage('File size is too large');
+            $this->setMessage($this->getTranslation('File size is too large'));
             $isValid = false;
         }
 

--- a/tests/Storage/FileSystemTest.php
+++ b/tests/Storage/FileSystemTest.php
@@ -9,6 +9,8 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
         // Path to test assets
         $this->assetsDirectory = dirname(__DIR__) . '/assets';
 
+        $this->translation = new \Upload\Translation('pt-BR');
+
         // Reset $_FILES superglobal
         $_FILES['foo'] = array(
             'name' => 'foo.txt',
@@ -75,5 +77,29 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
              ->method('isUploadedFile')
              ->will($this->returnValue(true));
         $this->assertTrue($file->upload());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInstantiationWithInvalidDirectoryUsingTranslation()
+    {
+        $storage = $this->getMock(
+            '\Upload\Storage\FileSystem',
+            array('upload'),
+            array('/foo', false, $this->translation)
+        );
+    }
+
+    /**
+     * Test won't overwrite existing file
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Validação do arquivo falhou
+     */
+    public function testWillNotOverwriteFileUsingTranslation()
+    {
+        $storage = new \Upload\Storage\FileSystem($this->assetsDirectory, false, $this->translation);
+        $file = new \Upload\File('foo', $storage, $this->translation);
+        $file->upload();
     }
 }

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class TranslationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Setup (each test)
+     */
+    public function setUp()
+    {
+        $this->translation = new \Upload\Translation('pt-BR');
+    }
+
+    /********************************************************************************
+    * Tests
+    *******************************************************************************/
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructionWithInvalidLanguage()
+    {
+        $translation = new \Upload\Translation('xy');
+    }
+
+    public function testConstructionWithValidLanguage()
+    {
+        $this->assertInstanceOf('Upload\Translation', $this->translation);
+    }
+
+    public function testTranslatedMessageWithoutPlaceholders()
+    {
+        $this->assertEquals('Arquivo já existe', $this->translation->getMessage('File already exists'));
+    }
+
+    public function testTranslatedMessageWithPlaceholders()
+    {
+        $this->assertEquals(
+            'Não foi possível encontrar o arquivo enviado com a chave: image',
+            $this->translation->getMessage('Cannot find uploaded file identified by key: %s', array('image'))
+         );
+    }
+}

--- a/tests/Validation/ExtensionTest.php
+++ b/tests/Validation/ExtensionTest.php
@@ -19,6 +19,8 @@ class ExtensionTest extends PHPUnit_Framework_TestCase
                       ->method('upload')
                       ->will($this->returnValue(true));
 
+        $this->translation = new \Upload\Translation('pt-BR');
+
         // Reset $_FILES superglobal
         $_FILES['foo'] = array(
             'name' => 'foo.txt',
@@ -39,5 +41,12 @@ class ExtensionTest extends PHPUnit_Framework_TestCase
         $file = new \Upload\File('foo', $this->storage);
         $validation = new \Upload\Validation\Extension('csv');
         $this->assertFalse($validation->validate($file));
+    }
+
+    public function testValidExtensionUsingTranslation()
+    {
+        $file = new \Upload\File('foo', $this->storage);
+        $validation = new \Upload\Validation\Extension('txt', $this->translation);
+        $this->assertTrue($validation->validate($file));
     }
 }

--- a/tests/Validation/MimetypeTest.php
+++ b/tests/Validation/MimetypeTest.php
@@ -19,6 +19,8 @@ class MimetypeTest extends PHPUnit_Framework_TestCase
                       ->method('upload')
                       ->will($this->returnValue(true));
 
+        $this->translation = new \Upload\Translation('pt-BR');
+
         // Reset $_FILES superglobal
         $_FILES['foo'] = array(
             'name' => 'foo.txt',
@@ -43,5 +45,16 @@ class MimetypeTest extends PHPUnit_Framework_TestCase
             'image/png'
         ));
         $this->assertFalse($validation->validate($file));
+    }
+
+    public function testInvalidMimetypeUsingTranslation()
+    {
+        $file = new \Upload\File('foo', $this->storage, $this->translation);
+        $validation = new \Upload\Validation\Mimetype(array(
+            'image/png'
+        ), $this->translation);
+
+        $this->assertFalse($validation->validate($file));
+        $this->assertEquals('Mimetype inválido', $validation->getMessage());
     }
 }

--- a/tests/Validation/SizeTest.php
+++ b/tests/Validation/SizeTest.php
@@ -19,6 +19,8 @@ class SizeTest extends PHPUnit_Framework_TestCase
                       ->method('upload')
                       ->will($this->returnValue(true));
 
+        $this->translation = new \Upload\Translation('pt-BR');
+
         // Reset $_FILES superglobal
         $_FILES['foo'] = array(
             'name' => 'foo.txt',
@@ -53,5 +55,13 @@ class SizeTest extends PHPUnit_Framework_TestCase
         $file = new \Upload\File('foo', $this->storage);
         $validation = new \Upload\Validation\Size('400B');
         $this->assertFalse($validation->validate($file));
+    }
+
+    public function testInvalidFileSizeUsingTranslation()
+    {
+        $file = new \Upload\File('foo', $this->storage, $this->translation);
+        $validation = new \Upload\Validation\Size(400, 0, $this->translation);
+        $this->assertFalse($validation->validate($file));
+        $this->assertEquals('Tamanho do arquivo muito grande', $validation->getMessage());
     }
 }


### PR DESCRIPTION
- created the \Upload\Translation class
- created the folder src/Upload/Language with 2 files: en.php and pt-BR.php
- the language files returns an array with messages as key / value
- the message keys are the original messages used in the project, so if the user
  decides to not use the validation class, it won't affect the behavior
- added a TranslationTest class
- added additional tests to existent test classes
- updated the README.md to display usage of the translation class
- added aditional methods to use the translation inside existing classes and because
  the project still gives support to PHP 5.3, trait usage was avoided