### PR TITLE
fix setname bug when uploads multipal files

### DIFF
--- a/src/Upload/FileInfo.php
+++ b/src/Upload/FileInfo.php
@@ -64,6 +64,12 @@ class FileInfo extends \SplFileInfo implements \Upload\FileInfoInterface
     protected $mimetype;
 
     /**
+     * File names key
+     * @var integer
+     */
+    protected static $namekey = 0;
+
+    /**
      * Constructor
      *
      * @param string $filePathname Absolute path to uploaded file on disk
@@ -101,6 +107,24 @@ class FileInfo extends \SplFileInfo implements \Upload\FileInfoInterface
         $name = preg_replace("/([^\w\s\d\-_~,;:\[\]\(\).]|[\.]{2,})/", "", $name);
         $name = basename($name);
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set Multiple file names (without extension)
+     *
+     * When uploads multipal files
+     *
+     * @param  array           $names
+     * @return \Upload\FileInfo Self
+     */
+    public function setMultipleNames($names)
+    {
+        if(is_array($names) && isset($names[self::$namekey])){
+            $name = $names[self::$namekey++];
+            $this->setName($name);
+        }
 
         return $this;
     }


### PR DESCRIPTION
When uploads multipal files, use setName action would rename all files to the same name.
so, use the setMultipleNames action with array params will solve the bug.

Example.
```
// rename the file
$fileCount = $file->count();
if($fileCount > 1){
    $fileNames = array();
    for($i = 0; $i < $fileCount; $i++){
        $fileNames[] = uniqid();
    }
    $file->setMultipleNames($fileNames);
}else{
    $file->setName(uniqid());
}
```
