### PR TITLE
Don't remove special characters from filename

### DIFF
--- a/src/Upload/FileInfo.php
+++ b/src/Upload/FileInfo.php
@@ -91,15 +91,11 @@ class FileInfo extends \SplFileInfo implements \Upload\FileInfoInterface
     /**
      * Set file name (without extension)
      * 
-     * It also makes sure file name is safe
-     *
      * @param  string           $name
      * @return \Upload\FileInfo Self
      */
     public function setName($name)
     {
-        $name = preg_replace("/([^\w\s\d\-_~,;:\[\]\(\).]|[\.]{2,})/", "", $name);
-        $name = basename($name);
         $this->name = $name;
 
         return $this;


### PR DESCRIPTION
Removing characters with accents etc removes too much information + don't remove the extension twice (already done in constructor)