### PR TITLE
Don't change the submitted filename

### DIFF
--- a/src/Upload/FileInfo.php
+++ b/src/Upload/FileInfo.php
@@ -98,7 +98,6 @@ class FileInfo extends \SplFileInfo implements \Upload\FileInfoInterface
      */
     public function setName($name)
     {
-        $name = preg_replace("/([^\w\s\d\-_~,;:\[\]\(\).]|[\.]{2,})/", "", $name);
         $name = basename($name);
         $this->name = $name;
 


### PR DESCRIPTION
Special characters were being removed (mainly non-ANSI) which doesn't seem to be desirable when using non-English languages.
E.g. the filename buffet-à-volonté.doc will be renamed to buffet--volont.doc

I couldn't find a proper way to make a filename "safe" across multiple languages so the best option seems to be to remove it altogether. I'm not sure why it had been added in the first place, it doesn't seem to be necessary.